### PR TITLE
Read node executable path from env

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#! node
+#!/usr/bin/env node
 import { existsSync } from "fs";
 import { relative } from "path";
 import Refactor = require('./lib');


### PR DESCRIPTION
The current shebang is unusual and does not work on unix machines.
I believe the "proper" nodejs executable shebang is `#!/usr/bin/env node`.
Changing the shebang to this works for me, and I suspect will work on windows too.

```
> 3h-refactor
module.js:549
    throw err;
    ^

Error: Cannot find module '/…/…/"use strict";
Object.defineProperty(exports, "__esModul'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Function.Module.runMain (module.js:693:10)
>
```